### PR TITLE
fix the target jar file path in release Dockerfile

### DIFF
--- a/Dockerfile_release
+++ b/Dockerfile_release
@@ -8,7 +8,7 @@ RUN mvn -Dmaven.test.skip=true clean package
 FROM mockserver/mockserver:5.15.0
 ARG VERSION
 ENV PROJECT_VERSION=${VERSION}
-COPY --from=maven-build /build/target/*.jar ./libs/application.jar
+COPY --from=maven-build /build/target/*.jar /libs/application.jar
 ENV SERVER_PORT=1080
 ENV DEBUG_PORT=5005
 EXPOSE ${SERVER_PORT}

--- a/README.md
+++ b/README.md
@@ -356,3 +356,5 @@ HTTP 204, No Content
 - Enhanced the version resolving algorithm
 ### 1.0.4
 - Introduced a release Dockerfile
+### 1.0.5
+- Fixed the target jar file path in release Dockerfile


### PR DESCRIPTION
Removes the . from the start of target jar file path to correctly copy the built jar file to libs folder.