### PR TITLE
Add Keycloak Admin API mock callback with support for users, groups, …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2026-03-24
+
+### Added
+
+- **Keycloak Admin REST API mock**: Read-only `GET /admin/realms/{realm}/...` endpoints returning
+  Keycloak-compatible JSON representations for users, groups, roles, and clients. Includes
+  filtering (`username`, `search`), pagination (`first`, `max`), and sub-resource navigation
+  (user role-mappings, user groups, group members, role users). Requires `admin` role when
+  `ENFORCE_TOKEN=true`.
+- **Group support**: New `GroupConfig` model with `name` and `subGroups`. Groups are configurable
+  per realm and exposed via the Admin API.
+- **Extended user metadata**: `UserConfig` now supports `email`, `firstName`, `lastName`, and
+  `groups` fields, included in Admin API user representations and the default configuration.
+- **Enriched default configuration**: `default-keycloak-config.json` now includes groups
+  (`admins`, `developers`, `viewers`), user metadata (email, name), and explicit
+  `serviceAccountRoles` for all clients.
+
+### Changed
+
+- Marked `jsr305` (compile-time annotations) and `slf4j-jdk14` (SLF4J binding) as
+  `<optional>true</optional>` so they are not pulled transitively by consumers.
+
 ## [2.1.0] - 2026-03-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ enforcement are all included without any external dependencies.
         * [Obtaining Tokens](#obtaining-tokens)
         * [OIDC Discovery and JWKS](#oidc-discovery-and-jwks)
         * [Custom Keycloak Configuration](#custom-keycloak-configuration)
+    * [Keycloak Admin REST API](#keycloak-admin-rest-api)
+        * [Admin Endpoints](#admin-endpoints)
+        * [Admin API Examples](#admin-api-examples)
     * [Token Enforcement and Role-Based Access](#token-enforcement-and-role-based-access)
         * [Validating Against an External Keycloak](#validating-against-an-external-keycloak)
         * [Role Matrix](#role-matrix)
@@ -46,8 +49,8 @@ enforcement are all included without any external dependencies.
 
 - **Zero-configuration TMF mocking** -- POST, GET, GET List, JSON Patch, Merge Patch, and DELETE with automatic `id`,
   `href`, state transitions, audit fields, and paging.
-- **Built-in Keycloak mock** -- real RSA-signed JWTs, OIDC discovery, JWKS endpoint, configurable realms / clients /
-  users / roles. No real Keycloak needed.
+- **Built-in Keycloak mock** -- real RSA-signed JWTs, OIDC discovery, JWKS endpoint, Admin REST API, configurable realms
+  / clients / users / roles / groups. No real Keycloak needed.
 - **Token enforcement** -- optionally validate Bearer tokens on every request, with role-based access control (reader /
   writer / admin).
 - **External IdP support** -- validate tokens against a real Keycloak (or any OIDC provider) via `JWKS_URI` or
@@ -87,13 +90,14 @@ java -Dmockserver.initializationClass=org.opentmf.mockserver.callback.JwksExpect
 
 On startup, the following endpoints are automatically registered for each configured realm (no expectations to create):
 
-| Endpoint                                               | Description                               |
-|--------------------------------------------------------|-------------------------------------------|
-| `GET /realms/{realm}/protocol/openid-connect/certs`    | JWKS (public keys for token verification) |
-| `GET /realms/{realm}/.well-known/openid-configuration` | OIDC discovery document                   |
-| `POST /realms/{realm}/protocol/openid-connect/token`   | Token endpoint (issue JWTs)               |
-| `GET /.well-known/jwks.json`                           | Global JWKS (backward-compatible)         |
-| `GET /mockserver/openapi`                              | OpenAPI 3.1 specification (YAML)          |
+| Endpoint                                               | Description                                        |
+|--------------------------------------------------------|----------------------------------------------------|
+| `GET /realms/{realm}/protocol/openid-connect/certs`    | JWKS (public keys for token verification)          |
+| `GET /realms/{realm}/.well-known/openid-configuration` | OIDC discovery document                            |
+| `POST /realms/{realm}/protocol/openid-connect/token`   | Token endpoint (issue JWTs)                        |
+| `GET /admin/realms/{realm}/...`                        | Keycloak Admin REST API (users, groups, roles, ...) |
+| `GET /.well-known/jwks.json`                           | Global JWKS (backward-compatible)                  |
+| `GET /mockserver/openapi`                              | OpenAPI 3.1 specification (YAML)                   |
 
 All issued tokens are **real, parsable, RSA-signed JWTs** with Keycloak-compatible claims (`iss`, `sub`, `azp`,
 `realm_access`, `resource_access`, `preferred_username`, `exp`, etc.).
@@ -112,13 +116,15 @@ The built-in default configuration provides a ready-to-use setup:
 | `client2`  | Confidential | `client2Secret` | `password`                  |
 | `uiClient` | Public       | --              | `password`, `refresh_token` |
 
+**Groups:** `admins`, `developers` (sub-groups: `backend`, `frontend`), `viewers`
+
 **Users:**
 
-| Username     | Password     | Roles                       |
-|--------------|--------------|-----------------------------|
-| `admin_usr`  | `admin_pwd`  | `admin`, `writer`, `reader` |
-| `writer_usr` | `writer_pwd` | `writer`, `reader`          |
-| `reader_usr` | `reader_pwd` | `reader`                    |
+| Username     | Password     | Roles                       | Groups        |
+|--------------|--------------|-----------------------------|---------------|
+| `admin_usr`  | `admin_pwd`  | `admin`, `writer`, `reader` | `admins`      |
+| `writer_usr` | `writer_pwd` | `writer`, `reader`          | `developers`  |
+| `reader_usr` | `reader_pwd` | `reader`                    | `viewers`     |
 
 ### Obtaining Tokens
 
@@ -187,45 +193,89 @@ The JSON format:
   "realms": [
     {
       "name": "my-realm",
-      "roles": [
-        "admin",
-        "user"
+      "roles": ["admin", "user"],
+      "groups": [
+        { "name": "team-a", "subGroups": ["backend", "frontend"] },
+        { "name": "team-b", "subGroups": [] }
       ],
       "clients": [
         {
           "clientId": "my-app",
           "clientSecret": "secret",
           "publicClient": false,
-          "allowedGrantTypes": [
-            "client_credentials",
-            "password"
-          ],
-          "serviceAccountRoles": [
-            "admin"
-          ]
+          "allowedGrantTypes": ["client_credentials", "password"],
+          "serviceAccountRoles": ["admin"]
         },
         {
           "clientId": "my-spa",
           "publicClient": true,
-          "allowedGrantTypes": [
-            "password",
-            "refresh_token"
-          ]
+          "allowedGrantTypes": ["password", "refresh_token"]
         }
       ],
       "users": [
         {
           "username": "alice",
           "password": "alice123",
-          "roles": [
-            "admin",
-            "user"
-          ]
+          "email": "alice@example.com",
+          "firstName": "Alice",
+          "lastName": "Smith",
+          "roles": ["admin", "user"],
+          "groups": ["team-a"]
         }
       ]
     }
   ]
 }
+```
+
+## Keycloak Admin REST API
+
+A read-only subset of the [Keycloak Admin REST API](https://www.keycloak.org/docs-api/latest/rest-api/index.html) is
+automatically registered for every configured realm. When token enforcement is enabled (`ENFORCE_TOKEN=true`), a valid
+Bearer token with the `admin` role is required.
+
+### Admin Endpoints
+
+| Endpoint                                                   | Description                            |
+|------------------------------------------------------------|----------------------------------------|
+| `GET /admin/realms/{realm}`                                | Realm representation                   |
+| `GET /admin/realms/{realm}/users`                          | List users (supports `username`, `search`, `first`, `max`) |
+| `GET /admin/realms/{realm}/users/count`                    | User count                             |
+| `GET /admin/realms/{realm}/users/{id}`                     | Single user by ID                      |
+| `GET /admin/realms/{realm}/users/{id}/role-mappings/realm` | Realm roles for a user                 |
+| `GET /admin/realms/{realm}/users/{id}/groups`              | Groups a user belongs to               |
+| `GET /admin/realms/{realm}/groups`                         | List groups (supports `search`, `first`, `max`) |
+| `GET /admin/realms/{realm}/groups/count`                   | Group count                            |
+| `GET /admin/realms/{realm}/groups/{id}`                    | Single group by ID (includes sub-groups) |
+| `GET /admin/realms/{realm}/groups/{id}/members`            | Members of a group                     |
+| `GET /admin/realms/{realm}/roles`                          | List realm roles                       |
+| `GET /admin/realms/{realm}/roles/{name}`                   | Single role by name                    |
+| `GET /admin/realms/{realm}/roles/{name}/users`             | Users with a specific role             |
+| `GET /admin/realms/{realm}/clients`                        | List clients                           |
+
+All IDs are deterministic UUIDs derived from the realm and entity name, so they remain stable across restarts.
+
+### Admin API Examples
+
+```shell
+# Get a token with admin role
+TOKEN=$(curl -s -X POST 'http://localhost:1080/realms/realm1/protocol/openid-connect/token' \
+  -d 'grant_type=client_credentials&client_id=client1&client_secret=client1Secret' | jq -r .access_token)
+
+# List all users
+curl -s -H "Authorization: Bearer $TOKEN" http://localhost:1080/admin/realms/realm1/users | jq .
+
+# Search users
+curl -s -H "Authorization: Bearer $TOKEN" 'http://localhost:1080/admin/realms/realm1/users?search=admin' | jq .
+
+# List groups
+curl -s -H "Authorization: Bearer $TOKEN" http://localhost:1080/admin/realms/realm1/groups | jq .
+
+# List realm roles
+curl -s -H "Authorization: Bearer $TOKEN" http://localhost:1080/admin/realms/realm1/roles | jq .
+
+# Get users with a specific role
+curl -s -H "Authorization: Bearer $TOKEN" http://localhost:1080/admin/realms/realm1/roles/admin/users | jq .
 ```
 
 ## Token Enforcement and Role-Based Access

--- a/opentmf-mockserver-openapi.yaml
+++ b/opentmf-mockserver-openapi.yaml
@@ -11,6 +11,7 @@ info:
     |-----|-------------|
     | **MockServer** | Control-plane API for managing expectations, verification, and server lifecycle. |
     | **Keycloak Mock** | OIDC endpoints automatically registered at startup (discovery, JWKS, token). |
+    | **Keycloak Admin** | Read-only Keycloak Admin REST API mock (users, groups, roles, clients). |
     | **TMF Resources** | Dynamic CRUD operations backed by class callbacks (user-registered expectations). |
   version: ${project.version}
   license:
@@ -29,6 +30,8 @@ tags:
     description: Control-plane API inherited from MockServer
   - name: Keycloak Mock
     description: Auto-registered OIDC / OAuth 2.0 endpoints
+  - name: Keycloak Admin
+    description: Read-only Keycloak Admin REST API mock
   - name: TMF Resources
     description: Dynamic CRUD for TMF-630 resources (callback-backed)
 
@@ -434,6 +437,359 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/TokenError"
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  #  Keycloak Admin REST API (read-only mock)
+  # ═══════════════════════════════════════════════════════════════════════════
+
+  /admin/realms/{realm}:
+    get:
+      tags: [ Keycloak Admin ]
+      operationId: getAdminRealm
+      summary: Get realm representation
+      parameters:
+        - $ref: "#/components/parameters/realm"
+      security:
+        - bearer: [ ]
+      responses:
+        "200":
+          description: Realm representation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminRealmRepresentation"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: Realm not found
+
+  /admin/realms/{realm}/users:
+    get:
+      tags: [ Keycloak Admin ]
+      operationId: listAdminUsers
+      summary: List users
+      parameters:
+        - $ref: "#/components/parameters/realm"
+        - name: username
+          in: query
+          schema:
+            type: string
+          description: Exact username filter
+        - name: search
+          in: query
+          schema:
+            type: string
+          description: Case-insensitive search across username, email, first/last name
+        - name: first
+          in: query
+          schema:
+            type: integer
+            default: 0
+        - name: max
+          in: query
+          schema:
+            type: integer
+            default: 100
+      security:
+        - bearer: [ ]
+      responses:
+        "200":
+          description: List of user representations
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AdminUserRepresentation"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /admin/realms/{realm}/users/count:
+    get:
+      tags: [ Keycloak Admin ]
+      operationId: countAdminUsers
+      summary: Count users
+      parameters:
+        - $ref: "#/components/parameters/realm"
+      security:
+        - bearer: [ ]
+      responses:
+        "200":
+          description: User count
+          content:
+            application/json:
+              schema:
+                type: integer
+
+  /admin/realms/{realm}/users/{userId}:
+    get:
+      tags: [ Keycloak Admin ]
+      operationId: getAdminUser
+      summary: Get user by ID
+      parameters:
+        - $ref: "#/components/parameters/realm"
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      security:
+        - bearer: [ ]
+      responses:
+        "200":
+          description: User representation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminUserRepresentation"
+        "404":
+          description: User not found
+
+  /admin/realms/{realm}/users/{userId}/role-mappings/realm:
+    get:
+      tags: [ Keycloak Admin ]
+      operationId: getAdminUserRealmRoles
+      summary: Get realm role mappings for a user
+      parameters:
+        - $ref: "#/components/parameters/realm"
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      security:
+        - bearer: [ ]
+      responses:
+        "200":
+          description: List of role representations
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AdminRoleRepresentation"
+
+  /admin/realms/{realm}/users/{userId}/groups:
+    get:
+      tags: [ Keycloak Admin ]
+      operationId: getAdminUserGroups
+      summary: Get groups a user belongs to
+      parameters:
+        - $ref: "#/components/parameters/realm"
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      security:
+        - bearer: [ ]
+      responses:
+        "200":
+          description: List of groups
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AdminGroupRepresentation"
+
+  /admin/realms/{realm}/groups:
+    get:
+      tags: [ Keycloak Admin ]
+      operationId: listAdminGroups
+      summary: List groups
+      parameters:
+        - $ref: "#/components/parameters/realm"
+        - name: search
+          in: query
+          schema:
+            type: string
+        - name: first
+          in: query
+          schema:
+            type: integer
+            default: 0
+        - name: max
+          in: query
+          schema:
+            type: integer
+            default: 100
+      security:
+        - bearer: [ ]
+      responses:
+        "200":
+          description: List of group representations
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AdminGroupRepresentation"
+
+  /admin/realms/{realm}/groups/count:
+    get:
+      tags: [ Keycloak Admin ]
+      operationId: countAdminGroups
+      summary: Count groups
+      parameters:
+        - $ref: "#/components/parameters/realm"
+      security:
+        - bearer: [ ]
+      responses:
+        "200":
+          description: Group count
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+
+  /admin/realms/{realm}/groups/{groupId}:
+    get:
+      tags: [ Keycloak Admin ]
+      operationId: getAdminGroup
+      summary: Get group by ID
+      parameters:
+        - $ref: "#/components/parameters/realm"
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      security:
+        - bearer: [ ]
+      responses:
+        "200":
+          description: Group representation with sub-groups
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminGroupRepresentation"
+        "404":
+          description: Group not found
+
+  /admin/realms/{realm}/groups/{groupId}/members:
+    get:
+      tags: [ Keycloak Admin ]
+      operationId: getAdminGroupMembers
+      summary: Get members of a group
+      parameters:
+        - $ref: "#/components/parameters/realm"
+        - name: groupId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      security:
+        - bearer: [ ]
+      responses:
+        "200":
+          description: List of user representations
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AdminUserRepresentation"
+
+  /admin/realms/{realm}/roles:
+    get:
+      tags: [ Keycloak Admin ]
+      operationId: listAdminRoles
+      summary: List realm roles
+      parameters:
+        - $ref: "#/components/parameters/realm"
+      security:
+        - bearer: [ ]
+      responses:
+        "200":
+          description: List of role representations
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AdminRoleRepresentation"
+
+  /admin/realms/{realm}/roles/{roleName}:
+    get:
+      tags: [ Keycloak Admin ]
+      operationId: getAdminRole
+      summary: Get role by name
+      parameters:
+        - $ref: "#/components/parameters/realm"
+        - name: roleName
+          in: path
+          required: true
+          schema:
+            type: string
+      security:
+        - bearer: [ ]
+      responses:
+        "200":
+          description: Role representation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminRoleRepresentation"
+        "404":
+          description: Role not found
+
+  /admin/realms/{realm}/roles/{roleName}/users:
+    get:
+      tags: [ Keycloak Admin ]
+      operationId: getAdminRoleUsers
+      summary: Get users with a specific role
+      parameters:
+        - $ref: "#/components/parameters/realm"
+        - name: roleName
+          in: path
+          required: true
+          schema:
+            type: string
+      security:
+        - bearer: [ ]
+      responses:
+        "200":
+          description: List of user representations
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AdminUserRepresentation"
+        "404":
+          description: Role not found
+
+  /admin/realms/{realm}/clients:
+    get:
+      tags: [ Keycloak Admin ]
+      operationId: listAdminClients
+      summary: List clients
+      parameters:
+        - $ref: "#/components/parameters/realm"
+      security:
+        - bearer: [ ]
+      responses:
+        "200":
+          description: List of client representations
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AdminClientRepresentation"
 
   # ═══════════════════════════════════════════════════════════════════════════
   #  TMF dynamic resources (callback-backed)
@@ -964,6 +1320,106 @@ components:
           example: Token has expired
         error_uri:
           type: string
+
+    # ── Keycloak Admin API schemas ───────────────────────────────────────────
+
+    AdminRealmRepresentation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        realm:
+          type: string
+        displayName:
+          type: string
+        enabled:
+          type: boolean
+        defaultRoles:
+          type: array
+          items:
+            type: string
+        sslRequired:
+          type: string
+
+    AdminUserRepresentation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        username:
+          type: string
+        email:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        enabled:
+          type: boolean
+        emailVerified:
+          type: boolean
+        createdTimestamp:
+          type: integer
+          format: int64
+        access:
+          type: object
+          additionalProperties:
+            type: boolean
+
+    AdminGroupRepresentation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        path:
+          type: string
+        subGroups:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdminGroupRepresentation"
+        subGroupCount:
+          type: integer
+
+    AdminRoleRepresentation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+        composite:
+          type: boolean
+        clientRole:
+          type: boolean
+        containerId:
+          type: string
+
+    AdminClientRepresentation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        clientId:
+          type: string
+        enabled:
+          type: boolean
+        publicClient:
+          type: boolean
+        protocol:
+          type: string
+        directAccessGrantsEnabled:
+          type: boolean
+        serviceAccountsEnabled:
+          type: boolean
 
     # ── TMF resource schemas ────────────────────────────────────────────────
 

--- a/pom.xml
+++ b/pom.xml
@@ -220,11 +220,12 @@
       <scope>runtime</scope>
     </dependency>
 
-    <!-- JSR 305 annotations (@Nullable, @Nonnull) -->
+    <!-- JSR 305 annotations (@Nullable, @Nonnull) – compile-time only -->
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>${jsr305.version}</version>
+      <optional>true</optional>
     </dependency>
 
     <!-- TSID (Time-Sorted IDs) -->
@@ -272,6 +273,7 @@
       <artifactId>slf4j-jdk14</artifactId>
       <version>${slf4j.version}</version>
       <scope>runtime</scope>
+      <optional>true</optional>
     </dependency>
 
     <!-- Test -->
@@ -361,7 +363,7 @@
                   <version>17</version>
                 </requireJavaVersion>
                 <requireMavenVersion>
-                  <version>3.6.3</version>
+                  <version>3.9.0</version>
                 </requireMavenVersion>
               </rules>
             </configuration>

--- a/src/main/java/org/opentmf/mockserver/callback/JwksExpectationInitializer.java
+++ b/src/main/java/org/opentmf/mockserver/callback/JwksExpectationInitializer.java
@@ -55,6 +55,7 @@ public class JwksExpectationInitializer implements ExpectationInitializer {
       expectations.add(realmJwks(oidcBase, jwksJson));
       expectations.add(realmDiscovery(realmName, baseUrl));
       expectations.add(realmToken(oidcBase));
+      expectations.add(realmAdmin(realmName));
     }
 
     Expectation openapi = openapiSpec();
@@ -143,6 +144,16 @@ public class JwksExpectationInitializer implements ExpectationInitializer {
                 HttpRequest.request().withMethod("POST").withPath(path), Times.unlimited(), null)
             .thenRespond(HttpClassCallback.callback(KeycloakTokenCallback.class.getName()));
     LOG.info("  POST {}", path);
+    return e;
+  }
+
+  private Expectation realmAdmin(String realmName) {
+    String path = "/admin/realms/" + realmName + ".*";
+    Expectation e =
+        Expectation.when(
+                HttpRequest.request().withMethod("GET").withPath(path), Times.unlimited(), null)
+            .thenRespond(HttpClassCallback.callback(KeycloakAdminCallback.class.getName()));
+    LOG.info("  GET  /admin/realms/{}/*", realmName);
     return e;
   }
 

--- a/src/main/java/org/opentmf/mockserver/callback/KeycloakAdminCallback.java
+++ b/src/main/java/org/opentmf/mockserver/callback/KeycloakAdminCallback.java
@@ -1,0 +1,418 @@
+package org.opentmf.mockserver.callback;
+
+import static org.opentmf.mockserver.util.JacksonUtil.writeAsString;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.mockserver.mock.action.ExpectationResponseCallback;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+import org.mockserver.model.MediaType;
+import org.opentmf.mockserver.keycloak.ClientConfig;
+import org.opentmf.mockserver.keycloak.GroupConfig;
+import org.opentmf.mockserver.keycloak.KeycloakConfig;
+import org.opentmf.mockserver.keycloak.RealmConfig;
+import org.opentmf.mockserver.keycloak.UserConfig;
+import org.opentmf.mockserver.token.TokenEnforcer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Keycloak Admin REST API mock callback.
+ *
+ * <p>Handles read-only {@code GET /admin/realms/{realm}/...} requests, returning
+ * Keycloak-compatible representations for users, groups, roles, and the realm itself.
+ * Requires a valid Bearer token with the {@code admin} role.
+ */
+public class KeycloakAdminCallback implements ExpectationResponseCallback {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KeycloakAdminCallback.class);
+  private static final long CREATED_TIMESTAMP = 1700000000000L;
+
+  @Override
+  public HttpResponse handle(HttpRequest httpRequest) {
+    HttpResponse authError = TokenEnforcer.getInstance().validateWithRoles(httpRequest, "admin");
+    if (authError != null) {
+      return authError;
+    }
+
+    String path = httpRequest.getPath().getValue();
+    String realmName = extractRealm(path);
+
+    KeycloakConfig config = KeycloakConfig.getInstance();
+    Optional<RealmConfig> realmOpt = config.findRealm(realmName);
+    if (realmOpt.isEmpty()) {
+      LOG.warn("Admin API: unknown realm '{}'", realmName);
+      return jsonResponse(404, Map.of("error", "Realm not found"));
+    }
+    RealmConfig realm = realmOpt.get();
+
+    String subPath = extractSubPath(path, realmName);
+    return route(httpRequest, realm, realmName, subPath);
+  }
+
+  private HttpResponse route(HttpRequest request, RealmConfig realm, String realmName,
+      String subPath) {
+    if (subPath.isEmpty()) {
+      return handleGetRealm(realm, realmName);
+    }
+
+    if (subPath.equals("/users/count")) {
+      return handleCountUsers(realm);
+    }
+    if (subPath.equals("/users")) {
+      return handleListUsers(request, realm, realmName);
+    }
+    if (subPath.startsWith("/users/")) {
+      return routeUser(realm, realmName, subPath.substring("/users/".length()));
+    }
+
+    if (subPath.equals("/groups/count")) {
+      return handleCountGroups(realm);
+    }
+    if (subPath.equals("/groups")) {
+      return handleListGroups(request, realm, realmName);
+    }
+    if (subPath.startsWith("/groups/")) {
+      return routeGroup(realm, realmName, subPath.substring("/groups/".length()));
+    }
+
+    if (subPath.equals("/roles")) {
+      return handleListRoles(realm, realmName);
+    }
+    if (subPath.startsWith("/roles/")) {
+      return routeRole(realm, realmName, subPath.substring("/roles/".length()));
+    }
+
+    if (subPath.equals("/clients")) {
+      return handleListClients(realm, realmName);
+    }
+
+    return jsonResponse(404, Map.of("error", "Unknown admin endpoint: " + subPath));
+  }
+
+  // ── Realm ─────────────────────────────────────────────────────────────────
+
+  private HttpResponse handleGetRealm(RealmConfig realm, String realmName) {
+    Map<String, Object> rep = new LinkedHashMap<>();
+    rep.put("id", stableId(realmName, "realm"));
+    rep.put("realm", realmName);
+    rep.put("displayName", realmName);
+    rep.put("enabled", true);
+    rep.put("registrationAllowed", false);
+    rep.put("resetPasswordAllowed", false);
+    rep.put("editUsernameAllowed", false);
+    rep.put("bruteForceProtected", false);
+    rep.put("loginWithEmailAllowed", true);
+    rep.put("duplicateEmailsAllowed", false);
+    rep.put("sslRequired", "external");
+    rep.put("defaultRoles", realm.getRoles());
+    return jsonResponse(200, rep);
+  }
+
+  // ── Users ─────────────────────────────────────────────────────────────────
+
+  private HttpResponse handleListUsers(HttpRequest request, RealmConfig realm, String realmName) {
+    String usernameFilter = queryParam(request, "username");
+    String searchFilter = queryParam(request, "search");
+    int first = queryParamInt(request, "first", 0);
+    int max = queryParamInt(request, "max", 100);
+
+    List<Map<String, Object>> results = realm.getUsers().stream()
+        .filter(u -> usernameFilter == null || u.getUsername().equals(usernameFilter))
+        .filter(u -> searchFilter == null
+            || u.getUsername().toLowerCase().contains(searchFilter.toLowerCase())
+            || (u.getEmail() != null
+                && u.getEmail().toLowerCase().contains(searchFilter.toLowerCase()))
+            || (u.getFirstName() != null
+                && u.getFirstName().toLowerCase().contains(searchFilter.toLowerCase()))
+            || (u.getLastName() != null
+                && u.getLastName().toLowerCase().contains(searchFilter.toLowerCase())))
+        .skip(first)
+        .limit(max)
+        .map(u -> userRepresentation(u, realmName))
+        .collect(Collectors.toList());
+    return jsonResponse(200, results);
+  }
+
+  private HttpResponse handleCountUsers(RealmConfig realm) {
+    return jsonResponse(200, realm.getUsers().size());
+  }
+
+  private HttpResponse routeUser(RealmConfig realm, String realmName, String rest) {
+    int slash = rest.indexOf('/');
+    String userId = slash < 0 ? rest : rest.substring(0, slash);
+    String tail = slash < 0 ? "" : rest.substring(slash);
+
+    Optional<UserConfig> userOpt = findUserById(realm, realmName, userId);
+    if (userOpt.isEmpty()) {
+      return jsonResponse(404, Map.of("error", "User not found"));
+    }
+    UserConfig user = userOpt.get();
+
+    if (tail.isEmpty()) {
+      return jsonResponse(200, userRepresentation(user, realmName));
+    }
+    if (tail.equals("/role-mappings/realm")) {
+      return handleUserRealmRoles(user, realmName);
+    }
+    if (tail.equals("/groups")) {
+      return handleUserGroups(user, realmName);
+    }
+    return jsonResponse(404, Map.of("error", "Unknown user sub-resource: " + tail));
+  }
+
+  private HttpResponse handleUserRealmRoles(UserConfig user, String realmName) {
+    List<Map<String, Object>> roles = user.getRoles().stream()
+        .map(r -> roleRepresentation(r, realmName))
+        .collect(Collectors.toList());
+    return jsonResponse(200, roles);
+  }
+
+  private HttpResponse handleUserGroups(UserConfig user, String realmName) {
+    List<Map<String, Object>> groups = user.getGroups().stream()
+        .map(g -> {
+          Map<String, Object> rep = new LinkedHashMap<>();
+          rep.put("id", stableId(realmName, "group:" + g));
+          rep.put("name", g);
+          rep.put("path", "/" + g);
+          return rep;
+        })
+        .collect(Collectors.toList());
+    return jsonResponse(200, groups);
+  }
+
+  // ── Groups ────────────────────────────────────────────────────────────────
+
+  private HttpResponse handleListGroups(HttpRequest request, RealmConfig realm, String realmName) {
+    String searchFilter = queryParam(request, "search");
+    int first = queryParamInt(request, "first", 0);
+    int max = queryParamInt(request, "max", 100);
+
+    List<Map<String, Object>> results = realm.getGroups().stream()
+        .filter(g -> searchFilter == null
+            || g.getName().toLowerCase().contains(searchFilter.toLowerCase()))
+        .skip(first)
+        .limit(max)
+        .map(g -> groupRepresentation(g, realmName))
+        .collect(Collectors.toList());
+    return jsonResponse(200, results);
+  }
+
+  private HttpResponse handleCountGroups(RealmConfig realm) {
+    return jsonResponse(200, Map.of("count", realm.getGroups().size()));
+  }
+
+  private HttpResponse routeGroup(RealmConfig realm, String realmName, String rest) {
+    int slash = rest.indexOf('/');
+    String groupId = slash < 0 ? rest : rest.substring(0, slash);
+    String tail = slash < 0 ? "" : rest.substring(slash);
+
+    Optional<GroupConfig> groupOpt = findGroupById(realm, realmName, groupId);
+    if (groupOpt.isEmpty()) {
+      return jsonResponse(404, Map.of("error", "Group not found"));
+    }
+    GroupConfig group = groupOpt.get();
+
+    if (tail.isEmpty()) {
+      return jsonResponse(200, groupRepresentation(group, realmName));
+    }
+    if (tail.equals("/members")) {
+      return handleGroupMembers(realm, group, realmName);
+    }
+    return jsonResponse(404, Map.of("error", "Unknown group sub-resource: " + tail));
+  }
+
+  private HttpResponse handleGroupMembers(RealmConfig realm, GroupConfig group, String realmName) {
+    List<Map<String, Object>> members = realm.getUsers().stream()
+        .filter(u -> u.getGroups().contains(group.getName()))
+        .map(u -> userRepresentation(u, realmName))
+        .collect(Collectors.toList());
+    return jsonResponse(200, members);
+  }
+
+  // ── Roles ─────────────────────────────────────────────────────────────────
+
+  private HttpResponse handleListRoles(RealmConfig realm, String realmName) {
+    List<Map<String, Object>> roles = realm.getRoles().stream()
+        .map(r -> roleRepresentation(r, realmName))
+        .collect(Collectors.toList());
+    return jsonResponse(200, roles);
+  }
+
+  private HttpResponse routeRole(RealmConfig realm, String realmName, String rest) {
+    int slash = rest.indexOf('/');
+    String roleName = slash < 0 ? rest : rest.substring(0, slash);
+    String tail = slash < 0 ? "" : rest.substring(slash);
+
+    if (!realm.getRoles().contains(roleName)) {
+      return jsonResponse(404, Map.of("error", "Role not found: " + roleName));
+    }
+
+    if (tail.isEmpty()) {
+      return jsonResponse(200, roleRepresentation(roleName, realmName));
+    }
+    if (tail.equals("/users")) {
+      return handleRoleUsers(realm, roleName, realmName);
+    }
+    return jsonResponse(404, Map.of("error", "Unknown role sub-resource: " + tail));
+  }
+
+  private HttpResponse handleRoleUsers(RealmConfig realm, String roleName, String realmName) {
+    List<Map<String, Object>> users = realm.getUsers().stream()
+        .filter(u -> u.getRoles().contains(roleName))
+        .map(u -> userRepresentation(u, realmName))
+        .collect(Collectors.toList());
+    return jsonResponse(200, users);
+  }
+
+  // ── Clients ───────────────────────────────────────────────────────────────
+
+  private HttpResponse handleListClients(RealmConfig realm, String realmName) {
+    List<Map<String, Object>> clients = realm.getClients().stream()
+        .map(c -> clientRepresentation(c, realmName))
+        .collect(Collectors.toList());
+    return jsonResponse(200, clients);
+  }
+
+  // ── Representations ───────────────────────────────────────────────────────
+
+  private Map<String, Object> userRepresentation(UserConfig user, String realmName) {
+    Map<String, Object> rep = new LinkedHashMap<>();
+    rep.put("id", stableId(realmName, "user:" + user.getUsername()));
+    rep.put("username", user.getUsername());
+    rep.put("email", user.getEmail() != null ? user.getEmail() : "");
+    rep.put("firstName", user.getFirstName() != null ? user.getFirstName() : "");
+    rep.put("lastName", user.getLastName() != null ? user.getLastName() : "");
+    rep.put("enabled", true);
+    rep.put("emailVerified", true);
+    rep.put("createdTimestamp", CREATED_TIMESTAMP);
+    rep.put("totp", false);
+    rep.put("disableableCredentialTypes", List.of());
+    rep.put("requiredActions", List.of());
+    rep.put("notBefore", 0);
+    Map<String, Boolean> access = new LinkedHashMap<>();
+    access.put("manageGroupMembership", true);
+    access.put("view", true);
+    access.put("mapRoles", true);
+    access.put("impersonate", true);
+    access.put("manage", true);
+    rep.put("access", access);
+    return rep;
+  }
+
+  private Map<String, Object> roleRepresentation(String roleName, String realmName) {
+    Map<String, Object> rep = new LinkedHashMap<>();
+    rep.put("id", stableId(realmName, "role:" + roleName));
+    rep.put("name", roleName);
+    rep.put("description", "");
+    rep.put("composite", false);
+    rep.put("clientRole", false);
+    rep.put("containerId", stableId(realmName, "realm"));
+    return rep;
+  }
+
+  private Map<String, Object> groupRepresentation(GroupConfig group, String realmName) {
+    Map<String, Object> rep = new LinkedHashMap<>();
+    rep.put("id", stableId(realmName, "group:" + group.getName()));
+    rep.put("name", group.getName());
+    rep.put("path", "/" + group.getName());
+
+    List<Map<String, Object>> subGroups = new ArrayList<>();
+    for (String sub : group.getSubGroups()) {
+      Map<String, Object> subRep = new LinkedHashMap<>();
+      subRep.put("id", stableId(realmName, "group:" + group.getName() + "/" + sub));
+      subRep.put("name", sub);
+      subRep.put("path", "/" + group.getName() + "/" + sub);
+      subRep.put("subGroups", List.of());
+      subGroups.add(subRep);
+    }
+    rep.put("subGroups", subGroups);
+    rep.put("subGroupCount", (long) subGroups.size());
+    return rep;
+  }
+
+  private Map<String, Object> clientRepresentation(ClientConfig client, String realmName) {
+    Map<String, Object> rep = new LinkedHashMap<>();
+    rep.put("id", stableId(realmName, "client:" + client.getClientId()));
+    rep.put("clientId", client.getClientId());
+    rep.put("enabled", true);
+    rep.put("publicClient", client.isPublicClient());
+    rep.put("protocol", "openid-connect");
+    rep.put("bearerOnly", false);
+    rep.put("directAccessGrantsEnabled",
+        client.getAllowedGrantTypes().contains("password"));
+    rep.put("serviceAccountsEnabled",
+        client.getAllowedGrantTypes().contains("client_credentials"));
+    return rep;
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  static String extractRealm(String path) {
+    String prefix = "/admin/realms/";
+    int start = path.indexOf(prefix);
+    if (start < 0) {
+      return "";
+    }
+    int nameStart = start + prefix.length();
+    int nameEnd = path.indexOf('/', nameStart);
+    return nameEnd < 0 ? path.substring(nameStart) : path.substring(nameStart, nameEnd);
+  }
+
+  private static String extractSubPath(String path, String realmName) {
+    String realmPrefix = "/admin/realms/" + realmName;
+    int idx = path.indexOf(realmPrefix);
+    if (idx < 0) {
+      return "";
+    }
+    return path.substring(idx + realmPrefix.length());
+  }
+
+  private Optional<UserConfig> findUserById(RealmConfig realm, String realmName, String userId) {
+    return realm.getUsers().stream()
+        .filter(u -> stableId(realmName, "user:" + u.getUsername()).equals(userId))
+        .findFirst();
+  }
+
+  private Optional<GroupConfig> findGroupById(RealmConfig realm, String realmName, String groupId) {
+    return realm.getGroups().stream()
+        .filter(g -> stableId(realmName, "group:" + g.getName()).equals(groupId))
+        .findFirst();
+  }
+
+  private static String stableId(String realmName, String entity) {
+    return UUID.nameUUIDFromBytes(
+        (realmName + ":" + entity).getBytes(StandardCharsets.UTF_8)).toString();
+  }
+
+  private static String queryParam(HttpRequest request, String name) {
+    String value = request.getFirstQueryStringParameter(name);
+    return (value != null && !value.isEmpty()) ? value : null;
+  }
+
+  private static int queryParamInt(HttpRequest request, String name, int defaultValue) {
+    String val = queryParam(request, name);
+    if (val == null) {
+      return defaultValue;
+    }
+    try {
+      return Integer.parseInt(val);
+    } catch (NumberFormatException e) {
+      return defaultValue;
+    }
+  }
+
+  private static HttpResponse jsonResponse(int status, Object body) {
+    return HttpResponse.response()
+        .withStatusCode(status)
+        .withContentType(MediaType.APPLICATION_JSON)
+        .withBody(writeAsString(body));
+  }
+}

--- a/src/main/java/org/opentmf/mockserver/keycloak/GroupConfig.java
+++ b/src/main/java/org/opentmf/mockserver/keycloak/GroupConfig.java
@@ -1,0 +1,26 @@
+package org.opentmf.mockserver.keycloak;
+
+import java.util.Collections;
+import java.util.List;
+
+public class GroupConfig {
+
+  private String name;
+  private List<String> subGroups = Collections.emptyList();
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public List<String> getSubGroups() {
+    return subGroups;
+  }
+
+  public void setSubGroups(List<String> subGroups) {
+    this.subGroups = subGroups;
+  }
+}

--- a/src/main/java/org/opentmf/mockserver/keycloak/RealmConfig.java
+++ b/src/main/java/org/opentmf/mockserver/keycloak/RealmConfig.java
@@ -8,6 +8,7 @@ public class RealmConfig {
 
   private String name;
   private List<String> roles = Collections.emptyList();
+  private List<GroupConfig> groups = Collections.emptyList();
   private List<ClientConfig> clients = Collections.emptyList();
   private List<UserConfig> users = Collections.emptyList();
 
@@ -43,11 +44,23 @@ public class RealmConfig {
     this.users = users;
   }
 
+  public List<GroupConfig> getGroups() {
+    return groups;
+  }
+
+  public void setGroups(List<GroupConfig> groups) {
+    this.groups = groups;
+  }
+
   public Optional<ClientConfig> findClient(String clientId) {
     return clients.stream().filter(c -> c.getClientId().equals(clientId)).findFirst();
   }
 
   public Optional<UserConfig> findUser(String username) {
     return users.stream().filter(u -> u.getUsername().equals(username)).findFirst();
+  }
+
+  public Optional<GroupConfig> findGroup(String name) {
+    return groups.stream().filter(g -> g.getName().equals(name)).findFirst();
   }
 }

--- a/src/main/java/org/opentmf/mockserver/keycloak/UserConfig.java
+++ b/src/main/java/org/opentmf/mockserver/keycloak/UserConfig.java
@@ -7,7 +7,11 @@ public class UserConfig {
 
   private String username;
   private String password;
+  private String email;
+  private String firstName;
+  private String lastName;
   private List<String> roles = Collections.emptyList();
+  private List<String> groups = Collections.emptyList();
 
   public String getUsername() {
     return username;
@@ -25,11 +29,43 @@ public class UserConfig {
     this.password = password;
   }
 
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public void setFirstName(String firstName) {
+    this.firstName = firstName;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+
+  public void setLastName(String lastName) {
+    this.lastName = lastName;
+  }
+
   public List<String> getRoles() {
     return roles;
   }
 
   public void setRoles(List<String> roles) {
     this.roles = roles;
+  }
+
+  public List<String> getGroups() {
+    return groups;
+  }
+
+  public void setGroups(List<String> groups) {
+    this.groups = groups;
   }
 }

--- a/src/main/resources/default-keycloak-config.json
+++ b/src/main/resources/default-keycloak-config.json
@@ -3,66 +3,60 @@
   "realms": [
     {
       "name": "realm1",
-      "roles": [
-        "admin",
-        "writer",
-        "reader"
+      "roles": ["admin", "writer", "reader"],
+      "groups": [
+        { "name": "admins", "subGroups": [] },
+        { "name": "developers", "subGroups": ["backend", "frontend"] },
+        { "name": "viewers", "subGroups": [] }
       ],
       "clients": [
         {
           "clientId": "client1",
           "clientSecret": "client1Secret",
           "publicClient": false,
-          "allowedGrantTypes": [
-            "client_credentials"
-          ],
-          "serviceAccountRoles": [
-            "admin",
-            "writer",
-            "reader"
-          ]
+          "allowedGrantTypes": ["client_credentials"],
+          "serviceAccountRoles": ["admin", "writer", "reader"]
         },
         {
           "clientId": "client2",
           "clientSecret": "client2Secret",
           "publicClient": false,
-          "allowedGrantTypes": [
-            "password"
-          ]
+          "allowedGrantTypes": ["password"],
+          "serviceAccountRoles": ["writer", "reader"]
         },
         {
           "clientId": "uiClient",
           "publicClient": true,
-          "allowedGrantTypes": [
-            "password",
-            "refresh_token"
-          ]
+          "allowedGrantTypes": ["password", "refresh_token"]
         }
       ],
       "users": [
         {
           "username": "admin_usr",
           "password": "admin_pwd",
-          "roles": [
-            "admin",
-            "writer",
-            "reader"
-          ]
+          "email": "admin@example.com",
+          "firstName": "Admin",
+          "lastName": "User",
+          "roles": ["admin", "writer", "reader"],
+          "groups": ["admins"]
         },
         {
           "username": "writer_usr",
           "password": "writer_pwd",
-          "roles": [
-            "writer",
-            "reader"
-          ]
+          "email": "writer@example.com",
+          "firstName": "Writer",
+          "lastName": "User",
+          "roles": ["writer", "reader"],
+          "groups": ["developers"]
         },
         {
           "username": "reader_usr",
           "password": "reader_pwd",
-          "roles": [
-            "reader"
-          ]
+          "email": "reader@example.com",
+          "firstName": "Reader",
+          "lastName": "User",
+          "roles": ["reader"],
+          "groups": ["viewers"]
         }
       ]
     }

--- a/src/test/java/org/opentmf/mockserver/callback/JwksExpectationInitializerTests.java
+++ b/src/test/java/org/opentmf/mockserver/callback/JwksExpectationInitializerTests.java
@@ -21,8 +21,8 @@ class JwksExpectationInitializerTests {
     Expectation[] expectations = initializer.initializeExpectations();
 
     int realmCount = KeycloakConfig.getInstance().getRealms().size();
-    // 1 global JWKS + 3 per realm (certs, discovery, token) + 1 OpenAPI spec
-    assertEquals(1 + realmCount * 3 + 1, expectations.length);
+    // 1 global JWKS + 4 per realm (certs, discovery, token, admin) + 1 OpenAPI spec
+    assertEquals(1 + realmCount * 4 + 1, expectations.length);
 
     // First expectation is the global JWKS
     Expectation globalJwks = expectations[0];

--- a/src/test/java/org/opentmf/mockserver/callback/KeycloakAdminCallbackTests.java
+++ b/src/test/java/org/opentmf/mockserver/callback/KeycloakAdminCallbackTests.java
@@ -1,0 +1,334 @@
+package org.opentmf.mockserver.callback;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockserver.model.HttpRequest.request;
+
+import org.junit.jupiter.api.Test;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
+import org.opentmf.mockserver.util.JacksonUtil;
+import tools.jackson.databind.JsonNode;
+
+class KeycloakAdminCallbackTests {
+
+  private final KeycloakAdminCallback callback = new KeycloakAdminCallback();
+
+  private static final String REALM = "realm1";
+  private static final String BASE = "/admin/realms/" + REALM;
+
+  // ── Realm ───────────────────────────────────────────────────────────────
+
+  @Test
+  void getRealm_returnsRealmRepresentation() {
+    HttpResponse resp = callback.handle(adminGet(BASE));
+    assertEquals(200, resp.getStatusCode());
+
+    JsonNode body = parse(resp);
+    assertEquals(REALM, body.get("realm").asText());
+    assertTrue(body.get("enabled").asBoolean());
+    assertNotNull(body.get("id"));
+    assertTrue(body.get("defaultRoles").isArray());
+  }
+
+  @Test
+  void unknownRealm_returns404() {
+    HttpResponse resp = callback.handle(adminGet("/admin/realms/nonexistent"));
+    assertEquals(404, resp.getStatusCode());
+  }
+
+  // ── Users ─────────────────────────────────────────────────────────────
+
+  @Test
+  void listUsers_returnsAllUsers() {
+    HttpResponse resp = callback.handle(adminGet(BASE + "/users"));
+    assertEquals(200, resp.getStatusCode());
+
+    JsonNode body = parse(resp);
+    assertTrue(body.isArray());
+    assertEquals(3, body.size());
+
+    JsonNode first = body.get(0);
+    assertNotNull(first.get("id"));
+    assertNotNull(first.get("username"));
+    assertTrue(first.get("enabled").asBoolean());
+  }
+
+  @Test
+  void listUsers_withUsernameFilter() {
+    HttpResponse resp = callback.handle(
+        adminGet(BASE + "/users").withQueryStringParameter("username", "admin_usr"));
+    assertEquals(200, resp.getStatusCode());
+
+    JsonNode body = parse(resp);
+    assertEquals(1, body.size());
+    assertEquals("admin_usr", body.get(0).get("username").asText());
+  }
+
+  @Test
+  void listUsers_withSearchFilter() {
+    HttpResponse resp = callback.handle(
+        adminGet(BASE + "/users").withQueryStringParameter("search", "writer"));
+    assertEquals(200, resp.getStatusCode());
+
+    JsonNode body = parse(resp);
+    assertEquals(1, body.size());
+    assertEquals("writer_usr", body.get(0).get("username").asText());
+  }
+
+  @Test
+  void listUsers_withPagination() {
+    HttpResponse resp = callback.handle(
+        adminGet(BASE + "/users")
+            .withQueryStringParameter("first", "1")
+            .withQueryStringParameter("max", "1"));
+    assertEquals(200, resp.getStatusCode());
+
+    JsonNode body = parse(resp);
+    assertEquals(1, body.size());
+  }
+
+  @Test
+  void countUsers_returnsCount() {
+    HttpResponse resp = callback.handle(adminGet(BASE + "/users/count"));
+    assertEquals(200, resp.getStatusCode());
+
+    JsonNode body = parse(resp);
+    assertEquals(3, body.asInt());
+  }
+
+  @Test
+  void getUserById_returnsUser() {
+    JsonNode users = parse(callback.handle(adminGet(BASE + "/users")));
+    String userId = users.get(0).get("id").asText();
+
+    HttpResponse resp = callback.handle(adminGet(BASE + "/users/" + userId));
+    assertEquals(200, resp.getStatusCode());
+
+    JsonNode body = parse(resp);
+    assertEquals(userId, body.get("id").asText());
+    assertNotNull(body.get("username"));
+    assertNotNull(body.get("email"));
+    assertNotNull(body.get("firstName"));
+    assertNotNull(body.get("lastName"));
+  }
+
+  @Test
+  void getUserById_unknownId_returns404() {
+    HttpResponse resp = callback.handle(
+        adminGet(BASE + "/users/00000000-0000-0000-0000-000000000000"));
+    assertEquals(404, resp.getStatusCode());
+  }
+
+  @Test
+  void userRealmRoles_returnsRoles() {
+    JsonNode users = parse(callback.handle(adminGet(BASE + "/users")));
+    String adminUserId = users.get(0).get("id").asText();
+
+    HttpResponse resp = callback.handle(
+        adminGet(BASE + "/users/" + adminUserId + "/role-mappings/realm"));
+    assertEquals(200, resp.getStatusCode());
+
+    JsonNode body = parse(resp);
+    assertTrue(body.isArray());
+    assertTrue(body.size() > 0);
+    assertNotNull(body.get(0).get("name"));
+    assertNotNull(body.get(0).get("id"));
+  }
+
+  @Test
+  void userGroups_returnsGroups() {
+    JsonNode users = parse(callback.handle(adminGet(BASE + "/users")));
+    String adminUserId = users.get(0).get("id").asText();
+
+    HttpResponse resp = callback.handle(
+        adminGet(BASE + "/users/" + adminUserId + "/groups"));
+    assertEquals(200, resp.getStatusCode());
+
+    JsonNode body = parse(resp);
+    assertTrue(body.isArray());
+    assertEquals(1, body.size());
+    assertEquals("admins", body.get(0).get("name").asText());
+  }
+
+  // ── Groups ────────────────────────────────────────────────────────────
+
+  @Test
+  void listGroups_returnsAllGroups() {
+    HttpResponse resp = callback.handle(adminGet(BASE + "/groups"));
+    assertEquals(200, resp.getStatusCode());
+
+    JsonNode body = parse(resp);
+    assertTrue(body.isArray());
+    assertEquals(3, body.size());
+    assertNotNull(body.get(0).get("id"));
+    assertNotNull(body.get(0).get("name"));
+    assertNotNull(body.get(0).get("path"));
+    assertNotNull(body.get(0).get("subGroups"));
+  }
+
+  @Test
+  void listGroups_withSearchFilter() {
+    HttpResponse resp = callback.handle(
+        adminGet(BASE + "/groups").withQueryStringParameter("search", "dev"));
+    assertEquals(200, resp.getStatusCode());
+
+    JsonNode body = parse(resp);
+    assertEquals(1, body.size());
+    assertEquals("developers", body.get(0).get("name").asText());
+  }
+
+  @Test
+  void countGroups_returnsCount() {
+    HttpResponse resp = callback.handle(adminGet(BASE + "/groups/count"));
+    assertEquals(200, resp.getStatusCode());
+
+    JsonNode body = parse(resp);
+    assertEquals(3, body.get("count").asInt());
+  }
+
+  @Test
+  void getGroupById_returnsGroupWithSubGroups() {
+    JsonNode groups = parse(callback.handle(adminGet(BASE + "/groups")));
+    String devGroupId = null;
+    for (JsonNode g : groups) {
+      if ("developers".equals(g.get("name").asText())) {
+        devGroupId = g.get("id").asText();
+        break;
+      }
+    }
+    assertNotNull(devGroupId);
+
+    HttpResponse resp = callback.handle(adminGet(BASE + "/groups/" + devGroupId));
+    assertEquals(200, resp.getStatusCode());
+
+    JsonNode body = parse(resp);
+    assertEquals("developers", body.get("name").asText());
+    assertEquals(2, body.get("subGroups").size());
+  }
+
+  @Test
+  void getGroupById_unknownId_returns404() {
+    HttpResponse resp = callback.handle(
+        adminGet(BASE + "/groups/00000000-0000-0000-0000-000000000000"));
+    assertEquals(404, resp.getStatusCode());
+  }
+
+  @Test
+  void groupMembers_returnsUsersInGroup() {
+    JsonNode groups = parse(callback.handle(adminGet(BASE + "/groups")));
+    String adminsGroupId = null;
+    for (JsonNode g : groups) {
+      if ("admins".equals(g.get("name").asText())) {
+        adminsGroupId = g.get("id").asText();
+        break;
+      }
+    }
+    assertNotNull(adminsGroupId);
+
+    HttpResponse resp = callback.handle(
+        adminGet(BASE + "/groups/" + adminsGroupId + "/members"));
+    assertEquals(200, resp.getStatusCode());
+
+    JsonNode body = parse(resp);
+    assertTrue(body.isArray());
+    assertEquals(1, body.size());
+    assertEquals("admin_usr", body.get(0).get("username").asText());
+  }
+
+  // ── Roles ─────────────────────────────────────────────────────────────
+
+  @Test
+  void listRoles_returnsAllRoles() {
+    HttpResponse resp = callback.handle(adminGet(BASE + "/roles"));
+    assertEquals(200, resp.getStatusCode());
+
+    JsonNode body = parse(resp);
+    assertTrue(body.isArray());
+    assertEquals(3, body.size());
+    assertNotNull(body.get(0).get("id"));
+    assertNotNull(body.get(0).get("name"));
+    assertFalse(body.get(0).get("clientRole").asBoolean());
+  }
+
+  @Test
+  void getRoleByName_returnsRole() {
+    HttpResponse resp = callback.handle(adminGet(BASE + "/roles/admin"));
+    assertEquals(200, resp.getStatusCode());
+
+    JsonNode body = parse(resp);
+    assertEquals("admin", body.get("name").asText());
+    assertNotNull(body.get("id"));
+    assertFalse(body.get("clientRole").asBoolean());
+  }
+
+  @Test
+  void getRoleByName_unknown_returns404() {
+    HttpResponse resp = callback.handle(adminGet(BASE + "/roles/nonexistent"));
+    assertEquals(404, resp.getStatusCode());
+  }
+
+  @Test
+  void roleUsers_returnsUsersWithRole() {
+    HttpResponse resp = callback.handle(adminGet(BASE + "/roles/admin/users"));
+    assertEquals(200, resp.getStatusCode());
+
+    JsonNode body = parse(resp);
+    assertTrue(body.isArray());
+    assertEquals(1, body.size());
+    assertEquals("admin_usr", body.get(0).get("username").asText());
+  }
+
+  @Test
+  void roleUsers_reader_returnsAll() {
+    HttpResponse resp = callback.handle(adminGet(BASE + "/roles/reader/users"));
+    assertEquals(200, resp.getStatusCode());
+
+    JsonNode body = parse(resp);
+    assertEquals(3, body.size());
+  }
+
+  // ── Clients ───────────────────────────────────────────────────────────
+
+  @Test
+  void listClients_returnsAllClients() {
+    HttpResponse resp = callback.handle(adminGet(BASE + "/clients"));
+    assertEquals(200, resp.getStatusCode());
+
+    JsonNode body = parse(resp);
+    assertTrue(body.isArray());
+    assertEquals(3, body.size());
+    assertNotNull(body.get(0).get("id"));
+    assertNotNull(body.get(0).get("clientId"));
+    assertEquals("openid-connect", body.get(0).get("protocol").asText());
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────
+
+  @Test
+  void extractRealm_parsesCorrectly() {
+    assertEquals("myRealm", KeycloakAdminCallback.extractRealm("/admin/realms/myRealm"));
+    assertEquals("myRealm", KeycloakAdminCallback.extractRealm("/admin/realms/myRealm/users"));
+    assertEquals("", KeycloakAdminCallback.extractRealm("/other/path"));
+  }
+
+  @Test
+  void stableIds_areDeterministic() {
+    JsonNode users1 = parse(callback.handle(adminGet(BASE + "/users")));
+    JsonNode users2 = parse(callback.handle(adminGet(BASE + "/users")));
+    assertEquals(users1.get(0).get("id").asText(), users2.get(0).get("id").asText());
+  }
+
+  @Test
+  void unknownSubEndpoint_returns404() {
+    HttpResponse resp = callback.handle(adminGet(BASE + "/unknown"));
+    assertEquals(404, resp.getStatusCode());
+  }
+
+  private static HttpRequest adminGet(String path) {
+    return request().withMethod("GET").withPath(path);
+  }
+
+  private static JsonNode parse(HttpResponse response) {
+    return JacksonUtil.readAsTree(response.getBodyAsString());
+  }
+}

--- a/src/test/java/org/opentmf/mockserver/keycloak/KeycloakConfigTests.java
+++ b/src/test/java/org/opentmf/mockserver/keycloak/KeycloakConfigTests.java
@@ -53,8 +53,12 @@ class KeycloakConfigTests {
     Optional<UserConfig> admin = realm.findUser("admin_usr");
     assertTrue(admin.isPresent());
     assertEquals("admin_pwd", admin.get().getPassword());
+    assertEquals("admin@example.com", admin.get().getEmail());
+    assertEquals("Admin", admin.get().getFirstName());
+    assertEquals("User", admin.get().getLastName());
     assertEquals(3, admin.get().getRoles().size());
     assertTrue(admin.get().getRoles().contains("admin"));
+    assertEquals(List.of("admins"), admin.get().getGroups());
 
     Optional<UserConfig> writer = realm.findUser("writer_usr");
     assertTrue(writer.isPresent());
@@ -64,6 +68,18 @@ class KeycloakConfigTests {
     assertTrue(reader.isPresent());
     assertEquals(1, reader.get().getRoles().size());
     assertTrue(reader.get().getRoles().contains("reader"));
+  }
+
+  @Test
+  void realm1HasExpectedGroups() {
+    RealmConfig realm = KeycloakConfig.getInstance().findRealm("realm1").orElseThrow();
+    assertEquals(3, realm.getGroups().size());
+    assertTrue(realm.findGroup("admins").isPresent());
+    assertTrue(realm.findGroup("developers").isPresent());
+    assertTrue(realm.findGroup("viewers").isPresent());
+
+    GroupConfig developers = realm.findGroup("developers").orElseThrow();
+    assertEquals(List.of("backend", "frontend"), developers.getSubGroups());
   }
 
   @Test
@@ -94,6 +110,7 @@ class KeycloakConfigTests {
             + "\"realms\":[{"
             + "  \"name\":\"testRealm\","
             + "  \"roles\":[\"role1\",\"role2\"],"
+            + "  \"groups\":[{\"name\":\"g1\",\"subGroups\":[\"sub1\",\"sub2\"]}],"
             + "  \"clients\":[{"
             + "    \"clientId\":\"c1\","
             + "    \"clientSecret\":\"s1\","
@@ -104,7 +121,11 @@ class KeycloakConfigTests {
             + "  \"users\":[{"
             + "    \"username\":\"u1\","
             + "    \"password\":\"p1\","
-            + "    \"roles\":[\"role1\",\"role2\"]"
+            + "    \"email\":\"u1@example.com\","
+            + "    \"firstName\":\"First\","
+            + "    \"lastName\":\"Last\","
+            + "    \"roles\":[\"role1\",\"role2\"],"
+            + "    \"groups\":[\"g1\"]"
             + "  }]"
             + "}]}";
 
@@ -121,6 +142,13 @@ class KeycloakConfigTests {
     assertEquals("testRealm", realm.getName());
     assertEquals(Arrays.asList("role1", "role2"), realm.getRoles());
 
+    assertEquals(1, realm.getGroups().size());
+    GroupConfig group = realm.getGroups().get(0);
+    assertEquals("g1", group.getName());
+    assertEquals(Arrays.asList("sub1", "sub2"), group.getSubGroups());
+    assertTrue(realm.findGroup("g1").isPresent());
+    assertFalse(realm.findGroup("nonexistent").isPresent());
+
     List<ClientConfig> clients = realm.getClients();
     assertEquals(1, clients.size());
     ClientConfig client = clients.get(0);
@@ -135,7 +163,11 @@ class KeycloakConfigTests {
     UserConfig user = users.get(0);
     assertEquals("u1", user.getUsername());
     assertEquals("p1", user.getPassword());
+    assertEquals("u1@example.com", user.getEmail());
+    assertEquals("First", user.getFirstName());
+    assertEquals("Last", user.getLastName());
     assertEquals(Arrays.asList("role1", "role2"), user.getRoles());
+    assertEquals(List.of("g1"), user.getGroups());
   }
 
   @Test
@@ -155,18 +187,34 @@ class KeycloakConfigTests {
     UserConfig user = new UserConfig();
     user.setUsername("usr");
     user.setPassword("pwd");
+    user.setEmail("usr@example.com");
+    user.setFirstName("First");
+    user.setLastName("Last");
     user.setRoles(List.of("reader"));
+    user.setGroups(List.of("g1"));
     assertEquals("usr", user.getUsername());
     assertEquals("pwd", user.getPassword());
+    assertEquals("usr@example.com", user.getEmail());
+    assertEquals("First", user.getFirstName());
+    assertEquals("Last", user.getLastName());
     assertEquals(List.of("reader"), user.getRoles());
+    assertEquals(List.of("g1"), user.getGroups());
+
+    GroupConfig group = new GroupConfig();
+    group.setName("g1");
+    group.setSubGroups(List.of("sub1"));
+    assertEquals("g1", group.getName());
+    assertEquals(List.of("sub1"), group.getSubGroups());
 
     RealmConfig realm = new RealmConfig();
     realm.setName("r1");
     realm.setRoles(List.of("a", "b"));
+    realm.setGroups(List.of(group));
     realm.setClients(List.of(client));
     realm.setUsers(List.of(user));
     assertEquals("r1", realm.getName());
     assertEquals(List.of("a", "b"), realm.getRoles());
+    assertEquals(1, realm.getGroups().size());
     assertEquals(1, realm.getClients().size());
     assertEquals(1, realm.getUsers().size());
 


### PR DESCRIPTION
…roles, and clients

- Introduce `KeycloakAdminCallback` for handling read-only `/admin/realms/{realm}` requests.
- Update `RealmConfig` and `UserConfig` to include groups, email, and personal details.
- Extend test coverage for realm, users, groups, roles, and clients in mock API.
- Modify `JwksExpectationInitializer` to account for additional endpoints.