### PR TITLE
Make token roles configurable per HTTP method and at custom claim path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.6] - 2026-06-26
+
+### Added
+
+- **Configurable required roles per HTTP method.** Five new env vars `ROLES_GET`, `ROLES_POST`,
+  `ROLES_PUT`, `ROLES_PATCH`, `ROLES_DELETE` accept a comma-separated list of role names; a request
+  whose token carries any one of the listed roles passes. Defaults preserve the historical
+  behaviour (`reader,writer,admin` for GET; `writer,admin` for POST/PUT/PATCH; `admin` for DELETE).
+  Setting a variable to the empty string disables the role check for that method while still
+  validating signature, expiry, and issuer. The Keycloak Admin REST API endpoints remain hard-coded
+  to require `admin`.
+- **Configurable roles claim path.** New env var `ROLES_CLAIM_PATH` accepts a dotted JSON path into
+  the token payload (e.g. `resource_access.my-client.roles`, `groups`, or a namespaced claim like
+  `https://example.com/roles`). The leaf must resolve to a JSON array of strings. When unset, the
+  enforcer keeps its previous fallback chain (`realm_access.roles`, then top-level `roles`); when
+  set, the configured path is the single source of truth and the default fallback is not consulted.
+
+### Changed
+
+- `TokenEnforcer` gains a `validateForRequest(HttpRequest)` helper that resolves the required
+  roles for the request's HTTP method from the configured per-method map. All eight TMF dynamic
+  callbacks (`DynamicGetCallback`, `DynamicGetListCallback`, `DynamicPostCallback`,
+  `DynamicPutCallback`, `DynamicJsonPatchCallback`, `DynamicMergePatchCallback`,
+  `DynamicJsonPatchCollectionCallback`, `DynamicDeleteCallback`) now route through it instead of
+  passing a hard-coded role list.
+
 ## [2.1.5] - 2026-06-19
 
 ### Added
@@ -251,6 +277,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release.
+
+[2.1.6]: https://github.com/opentmf/opentmf-mockserver/compare/2.1.5...2.1.6
 
 [2.1.5]: https://github.com/opentmf/opentmf-mockserver/compare/2.1.4...2.1.5
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ enforcement are all included without any external dependencies.
     * [Token Enforcement and Role-Based Access](#token-enforcement-and-role-based-access)
         * [Validating Against an External Keycloak](#validating-against-an-external-keycloak)
         * [Role Matrix](#role-matrix)
+        * [Customizing Required Roles per HTTP Method](#customizing-required-roles-per-http-method)
+        * [Customizing the Roles Claim Path](#customizing-the-roles-claim-path)
     * [Environment Variables](#environment-variables)
     * [Content-Range Calculations](#content-range-calculations)
     * [API Reference](#api-reference)
@@ -809,15 +811,70 @@ When `TOKEN_ISSUER` is set, the `iss` claim in the token is also validated again
 
 ### Role Matrix
 
-Roles are extracted from the JWT's `realm_access.roles` claim (Keycloak standard).
+By default, roles are extracted from the JWT's `realm_access.roles` claim (Keycloak standard); when
+that claim is absent, a top-level `roles` claim is used as a fallback.
 
-| Operation                     | Required Role (any of)      |
-|-------------------------------|-----------------------------|
-| GET, GET List                 | `reader`, `writer`, `admin` |
-| POST, JSON Patch, Merge Patch | `writer`, `admin`           |
-| DELETE                        | `admin`                     |
+| HTTP Method | Default Required Role (any of) | Configurable via |
+|-------------|--------------------------------|------------------|
+| GET         | `reader`, `writer`, `admin`    | `ROLES_GET`      |
+| POST        | `writer`, `admin`              | `ROLES_POST`     |
+| PUT         | `writer`, `admin`              | `ROLES_PUT`      |
+| PATCH       | `writer`, `admin`              | `ROLES_PATCH`    |
+| DELETE      | `admin`                        | `ROLES_DELETE`   |
 
-Insufficient roles return **403 Forbidden**; missing/invalid tokens return **401 Unauthorized**.
+The GET List endpoint shares `ROLES_GET` with single-resource GET. Insufficient roles return
+**403 Forbidden**; missing/invalid tokens return **401 Unauthorized**.
+
+### Customizing Required Roles per HTTP Method
+
+Each method's required roles can be overridden with the matching env var. The value is a
+comma-separated list -- a request whose token carries **any one** of the listed roles passes.
+
+```shell
+docker run -p 1080:1080 \
+  -e ENFORCE_TOKEN=true \
+  -e TOKEN_ISSUER=https://keycloak.example.com/realms/myrealm \
+  -e ROLES_GET=service-reader,service-admin \
+  -e ROLES_POST=service-writer,service-admin \
+  -e ROLES_DELETE=service-admin \
+  local/opentmf-mockserver:latest
+```
+
+Setting an env var to the **empty string** disables the role check for that method, keeping only
+signature/expiry/issuer validation:
+
+```shell
+# Anyone with a signature-valid token can GET; writes still require the default writer/admin
+-e ROLES_GET=
+```
+
+The internal Keycloak Admin REST API endpoints (`/admin/realms/...`) always require `admin` and
+are not affected by these variables.
+
+### Customizing the Roles Claim Path
+
+If your Keycloak (or other IdP) emits roles at a different location than `realm_access.roles`, set
+`ROLES_CLAIM_PATH` to a dotted JSON path into the token payload. The leaf must resolve to a JSON
+array of strings.
+
+```shell
+# Keycloak client roles for a specific client
+-e ROLES_CLAIM_PATH=resource_access.my-client.roles
+
+# Flat list at top level
+-e ROLES_CLAIM_PATH=groups
+
+# Auth0-style namespaced custom claim
+-e ROLES_CLAIM_PATH=https://example.com/roles
+```
+
+When `ROLES_CLAIM_PATH` is set, the default `realm_access.roles` / top-level `roles` fallback chain
+is **not** consulted -- the configured path is the single source of truth. If any segment of the
+path is missing in the token, or the leaf is not an array of strings, the token is treated as
+having no roles (which means **403** for any method whose `ROLES_*` list is non-empty).
+
+Note: client IDs that contain dots (e.g. `resource_access.foo.bar.com.roles`) are not supported by
+the dotted-path parser; the dots would be interpreted as path separators.
 
 ## Environment Variables
 
@@ -833,6 +890,12 @@ Insufficient roles return **403 Forbidden**; missing/invalid tokens return **401
 | `ENFORCE_TOKEN`                       | `false`                      | `true` to require valid Bearer JWT on all dynamic callbacks       |
 | `TOKEN_ISSUER`                        | --                           | Expected `iss` claim; also enables OIDC auto-discovery            |
 | `JWKS_URI`                            | --                           | Explicit JWKS endpoint URL (takes precedence over discovery)      |
+| `ROLES_CLAIM_PATH`                    | --                           | Dotted path to the roles array in the token (e.g. `resource_access.my-client.roles`). Unset = `realm_access.roles` with top-level `roles` fallback |
+| `ROLES_GET`                           | `reader,writer,admin`        | Comma-separated roles accepted on GET (single and list). Empty = skip role check |
+| `ROLES_POST`                          | `writer,admin`               | Comma-separated roles accepted on POST. Empty = skip role check   |
+| `ROLES_PUT`                           | `writer,admin`               | Comma-separated roles accepted on PUT. Empty = skip role check    |
+| `ROLES_PATCH`                         | `writer,admin`               | Comma-separated roles accepted on PATCH (merge / JSON Patch / collection). Empty = skip role check |
+| `ROLES_DELETE`                        | `admin`                      | Comma-separated roles accepted on DELETE. Empty = skip role check |
 
 ## Content-Range Calculations
 

--- a/src/main/java/org/opentmf/mockserver/callback/DynamicDeleteCallback.java
+++ b/src/main/java/org/opentmf/mockserver/callback/DynamicDeleteCallback.java
@@ -37,7 +37,7 @@ public class DynamicDeleteCallback implements ExpectationResponseCallback {
 
   @Override
   public HttpResponse handle(HttpRequest httpRequest) {
-    HttpResponse authError = TokenEnforcer.getInstance().validateWithRoles(httpRequest, "admin");
+    HttpResponse authError = TokenEnforcer.getInstance().validateForRequest(httpRequest);
     if (authError != null) {
       return authError;
     }

--- a/src/main/java/org/opentmf/mockserver/callback/DynamicGetCallback.java
+++ b/src/main/java/org/opentmf/mockserver/callback/DynamicGetCallback.java
@@ -49,8 +49,7 @@ public class DynamicGetCallback implements ExpectationResponseCallback {
 
   @Override
   public HttpResponse handle(HttpRequest httpRequest) {
-    HttpResponse authError =
-        TokenEnforcer.getInstance().validateWithRoles(httpRequest, "reader", "writer", "admin");
+    HttpResponse authError = TokenEnforcer.getInstance().validateForRequest(httpRequest);
     if (authError != null) {
       return authError;
     }

--- a/src/main/java/org/opentmf/mockserver/callback/DynamicGetListCallback.java
+++ b/src/main/java/org/opentmf/mockserver/callback/DynamicGetListCallback.java
@@ -61,8 +61,7 @@ public class DynamicGetListCallback implements ExpectationResponseCallback {
 
   @Override
   public HttpResponse handle(HttpRequest httpRequest) {
-    HttpResponse authError =
-        TokenEnforcer.getInstance().validateWithRoles(httpRequest, "reader", "writer", "admin");
+    HttpResponse authError = TokenEnforcer.getInstance().validateForRequest(httpRequest);
     if (authError != null) {
       return authError;
     }

--- a/src/main/java/org/opentmf/mockserver/callback/DynamicJsonPatchCallback.java
+++ b/src/main/java/org/opentmf/mockserver/callback/DynamicJsonPatchCallback.java
@@ -45,8 +45,7 @@ public class DynamicJsonPatchCallback implements ExpectationResponseCallback {
 
   @Override
   public HttpResponse handle(HttpRequest httpRequest) {
-    HttpResponse authError =
-        TokenEnforcer.getInstance().validateWithRoles(httpRequest, "writer", "admin");
+    HttpResponse authError = TokenEnforcer.getInstance().validateForRequest(httpRequest);
     if (authError != null) {
       return authError;
     }

--- a/src/main/java/org/opentmf/mockserver/callback/DynamicJsonPatchCollectionCallback.java
+++ b/src/main/java/org/opentmf/mockserver/callback/DynamicJsonPatchCollectionCallback.java
@@ -55,8 +55,7 @@ public class DynamicJsonPatchCollectionCallback implements ExpectationResponseCa
 
   @Override
   public HttpResponse handle(HttpRequest httpRequest) {
-    HttpResponse authError =
-        TokenEnforcer.getInstance().validateWithRoles(httpRequest, "writer", "admin");
+    HttpResponse authError = TokenEnforcer.getInstance().validateForRequest(httpRequest);
     if (authError != null) {
       return authError;
     }

--- a/src/main/java/org/opentmf/mockserver/callback/DynamicMergePatchCallback.java
+++ b/src/main/java/org/opentmf/mockserver/callback/DynamicMergePatchCallback.java
@@ -45,8 +45,7 @@ public class DynamicMergePatchCallback implements ExpectationResponseCallback {
 
   @Override
   public HttpResponse handle(HttpRequest httpRequest) {
-    HttpResponse authError =
-        TokenEnforcer.getInstance().validateWithRoles(httpRequest, "writer", "admin");
+    HttpResponse authError = TokenEnforcer.getInstance().validateForRequest(httpRequest);
     if (authError != null) {
       return authError;
     }

--- a/src/main/java/org/opentmf/mockserver/callback/DynamicPostCallback.java
+++ b/src/main/java/org/opentmf/mockserver/callback/DynamicPostCallback.java
@@ -103,8 +103,7 @@ public class DynamicPostCallback implements ExpectationResponseCallback {
 
   @Override
   public HttpResponse handle(HttpRequest httpRequest) {
-    HttpResponse authError =
-        TokenEnforcer.getInstance().validateWithRoles(httpRequest, "writer", "admin");
+    HttpResponse authError = TokenEnforcer.getInstance().validateForRequest(httpRequest);
     if (authError != null) {
       return authError;
     }

--- a/src/main/java/org/opentmf/mockserver/callback/DynamicPutCallback.java
+++ b/src/main/java/org/opentmf/mockserver/callback/DynamicPutCallback.java
@@ -57,8 +57,7 @@ public class DynamicPutCallback implements ExpectationResponseCallback {
 
   @Override
   public HttpResponse handle(HttpRequest httpRequest) {
-    HttpResponse authError =
-        TokenEnforcer.getInstance().validateWithRoles(httpRequest, "writer", "admin");
+    HttpResponse authError = TokenEnforcer.getInstance().validateForRequest(httpRequest);
     if (authError != null) {
       return authError;
     }

--- a/src/main/java/org/opentmf/mockserver/token/TokenEnforcer.java
+++ b/src/main/java/org/opentmf/mockserver/token/TokenEnforcer.java
@@ -24,7 +24,9 @@ import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import org.mockserver.model.HttpRequest;
@@ -39,7 +41,8 @@ import tools.jackson.databind.JsonNode;
 /**
  * Validates Bearer JWT tokens on incoming requests.
  *
- * <p>Controlled by three configuration knobs (env var or system property):
+ * <p>Controlled by these configuration knobs (env var or system property, env wins when both
+ * present):
  *
  * <ul>
  *   <li>{@code ENFORCE_TOKEN} / {@code enforce.token} -- {@code true} to enable (default {@code
@@ -48,6 +51,16 @@ import tools.jackson.databind.JsonNode;
  *       OIDC auto-discovery of the JWKS URI when {@code JWKS_URI} is not set
  *   <li>{@code JWKS_URI} / {@code jwks.uri} -- explicit JWKS endpoint (takes precedence over
  *       discovery)
+ *   <li>{@code ROLES_CLAIM_PATH} / {@code roles.claim.path} -- dotted JSON path to the roles array
+ *       inside the token (e.g. {@code realm_access.roles}, {@code resource_access.my-client.roles},
+ *       {@code groups}). When unset, the enforcer tries {@code realm_access.roles} and falls back
+ *       to a top-level {@code roles} claim.
+ *   <li>{@code ROLES_GET} / {@code ROLES_POST} / {@code ROLES_PUT} / {@code ROLES_PATCH} /
+ *       {@code ROLES_DELETE} -- comma-separated list of roles required for each HTTP method.
+ *       Defaults preserve the historical behaviour ({@code reader,writer,admin} for GET;
+ *       {@code writer,admin} for POST/PUT/PATCH; {@code admin} for DELETE). An empty value
+ *       (e.g. {@code ROLES_GET=}) disables the role check for that method while still validating
+ *       signature and expiry.
  * </ul>
  *
  * <p>When neither {@code JWKS_URI} nor {@code TOKEN_ISSUER} is set, the built-in mock keys from
@@ -57,10 +70,18 @@ public final class TokenEnforcer {
 
   private static final Logger LOG = LoggerFactory.getLogger(TokenEnforcer.class);
 
+  private static final String DEFAULT_ROLES_GET = "reader,writer,admin";
+  private static final String DEFAULT_ROLES_POST = "writer,admin";
+  private static final String DEFAULT_ROLES_PUT = "writer,admin";
+  private static final String DEFAULT_ROLES_PATCH = "writer,admin";
+  private static final String DEFAULT_ROLES_DELETE = "admin";
+
   private static volatile TokenEnforcer instance;
 
   private final boolean enabled;
   private final String expectedIssuer;
+  private final String rolesClaimPath;
+  private final Map<String, String[]> rolesByMethod;
   private final ConfigurableJWTProcessor<SecurityContext> jwtProcessor;
   private final String initError;
 
@@ -80,7 +101,34 @@ public final class TokenEnforcer {
     this(
         Boolean.parseBoolean(resolve("ENFORCE_TOKEN", "enforce.token", "false")),
         resolve("TOKEN_ISSUER", "token.issuer", ""),
-        resolve("JWKS_URI", "jwks.uri", ""));
+        resolve("JWKS_URI", "jwks.uri", ""),
+        resolve("ROLES_CLAIM_PATH", "roles.claim.path", ""),
+        rolesByMethodFromEnv());
+  }
+
+  private static Map<String, String[]> rolesByMethodFromEnv() {
+    Map<String, String[]> map = new LinkedHashMap<>();
+    map.put("GET", parseRoles(resolve("ROLES_GET", "roles.get", DEFAULT_ROLES_GET)));
+    map.put("POST", parseRoles(resolve("ROLES_POST", "roles.post", DEFAULT_ROLES_POST)));
+    map.put("PUT", parseRoles(resolve("ROLES_PUT", "roles.put", DEFAULT_ROLES_PUT)));
+    map.put("PATCH", parseRoles(resolve("ROLES_PATCH", "roles.patch", DEFAULT_ROLES_PATCH)));
+    map.put("DELETE", parseRoles(resolve("ROLES_DELETE", "roles.delete", DEFAULT_ROLES_DELETE)));
+    return map;
+  }
+
+  private static String[] parseRoles(String csv) {
+    if (csv == null || csv.isEmpty()) {
+      return new String[0];
+    }
+    String[] parts = csv.split(",");
+    List<String> out = new java.util.ArrayList<>(parts.length);
+    for (String part : parts) {
+      String trimmed = part.trim();
+      if (!trimmed.isEmpty()) {
+        out.add(trimmed);
+      }
+    }
+    return out.toArray(new String[0]);
   }
 
   /**
@@ -93,9 +141,27 @@ public final class TokenEnforcer {
    *     keys)
    */
   public TokenEnforcer(boolean enabled, String issuerConfig, String jwksUriConfig) {
+    this(enabled, issuerConfig, jwksUriConfig, "", rolesByMethodFromEnv());
+  }
+
+  /**
+   * Full-control constructor used by the no-arg variant. Tests should prefer the JWKSource-backed
+   * constructor below.
+   */
+  public TokenEnforcer(
+      boolean enabled,
+      String issuerConfig,
+      String jwksUriConfig,
+      String rolesClaimPathConfig,
+      Map<String, String[]> rolesByMethod) {
     this.enabled = enabled;
     if (issuerConfig == null) issuerConfig = "";
     if (jwksUriConfig == null) jwksUriConfig = "";
+    this.rolesClaimPath =
+        (rolesClaimPathConfig == null || rolesClaimPathConfig.isEmpty())
+            ? null
+            : rolesClaimPathConfig;
+    this.rolesByMethod = Collections.unmodifiableMap(rolesByMethod);
 
     if (!enabled) {
       LOG.info("Token enforcement is DISABLED");
@@ -120,11 +186,13 @@ public final class TokenEnforcer {
     this.initError = error;
 
     LOG.info(
-        "Token enforcement is ENABLED (issuer={}, jwks={})",
+        "Token enforcement is ENABLED (issuer={}, jwks={}, rolesClaimPath={}, rolesByMethod={})",
         expectedIssuer != null ? expectedIssuer : "<any>",
         jwksUriConfig.isEmpty()
             ? (issuerConfig.isEmpty() ? "<built-in>" : "<discovered>")
-            : jwksUriConfig);
+            : jwksUriConfig,
+        rolesClaimPath != null ? rolesClaimPath : "<default: realm_access.roles | roles>",
+        describeRolesByMethod());
   }
 
   /**
@@ -132,9 +200,27 @@ public final class TokenEnforcer {
    * entirely.
    */
   TokenEnforcer(boolean enabled, String expectedIssuer, JWKSource<SecurityContext> keySource) {
+    this(enabled, expectedIssuer, keySource, "", rolesByMethodFromEnv());
+  }
+
+  /**
+   * Package-private constructor for testing with an explicit key source plus role config. Bypasses
+   * OIDC discovery entirely.
+   */
+  TokenEnforcer(
+      boolean enabled,
+      String expectedIssuer,
+      JWKSource<SecurityContext> keySource,
+      String rolesClaimPathConfig,
+      Map<String, String[]> rolesByMethod) {
     this.enabled = enabled;
     this.expectedIssuer =
         (expectedIssuer == null || expectedIssuer.isEmpty()) ? null : expectedIssuer;
+    this.rolesClaimPath =
+        (rolesClaimPathConfig == null || rolesClaimPathConfig.isEmpty())
+            ? null
+            : rolesClaimPathConfig;
+    this.rolesByMethod = Collections.unmodifiableMap(rolesByMethod);
 
     if (!enabled) {
       this.jwtProcessor = null;
@@ -167,9 +253,26 @@ public final class TokenEnforcer {
   }
 
   /**
+   * Validates the Bearer token and resolves the required roles from the configured per-method map
+   * ({@code ROLES_GET}, {@code ROLES_POST}, ...) based on {@link HttpRequest#getMethod()}. An empty
+   * configured list for the method means signature/expiry/issuer are still checked but no role
+   * check is performed.
+   *
+   * @return {@code null} if validation passes (or enforcement is disabled); an HTTP 401 or 403
+   *     response otherwise.
+   */
+  public HttpResponse validateForRequest(HttpRequest request) {
+    String method = request.getMethod().getValue();
+    String[] required =
+        rolesByMethod.getOrDefault(method.toUpperCase(Locale.ROOT), new String[0]);
+    return validateWithRoles(request, required);
+  }
+
+  /**
    * Validates the Bearer token and optionally checks that the token carries at least one of the
-   * specified roles. Roles are extracted from the Keycloak {@code realm_access.roles} claim first,
-   * falling back to a top-level {@code roles} claim.
+   * specified roles. Roles are extracted from {@code ROLES_CLAIM_PATH} when configured, otherwise
+   * from the Keycloak {@code realm_access.roles} claim first, falling back to a top-level
+   * {@code roles} claim.
    *
    * @param request the incoming HTTP request
    * @param requiredRoles roles of which the token must contain at least one; if empty, role
@@ -294,7 +397,11 @@ public final class TokenEnforcer {
   // ---- role extraction ----
 
   @SuppressWarnings("unchecked")
-  private static Set<String> extractRoles(JWTClaimsSet claims) {
+  private Set<String> extractRoles(JWTClaimsSet claims) {
+    if (rolesClaimPath != null) {
+      return extractRolesAtPath(claims, rolesClaimPath);
+    }
+
     Set<String> roles = new HashSet<>();
     try {
       Map<String, Object> realmAccess = claims.getJSONObjectClaim("realm_access");
@@ -309,7 +416,7 @@ public final class TokenEnforcer {
         }
       }
     } catch (ParseException ignored) {
-      /* claim absent or wrong type */
+      // claim absent or wrong type
     }
 
     if (roles.isEmpty()) {
@@ -319,10 +426,40 @@ public final class TokenEnforcer {
           roles.addAll(topLevel);
         }
       } catch (ParseException ignored) {
-        /* claim absent or wrong type */
+        // claim absent or wrong type
       }
     }
 
+    return Collections.unmodifiableSet(roles);
+  }
+
+  /**
+   * Traverses the dotted path against the token's claims. Each segment indexes into a JSON object;
+   * the final segment must resolve to a JSON array of strings. Returns an empty set if any segment
+   * is missing or the leaf is the wrong shape.
+   */
+  @SuppressWarnings("unchecked")
+  private static Set<String> extractRolesAtPath(JWTClaimsSet claims, String path) {
+    String[] segments = path.split("\\.");
+    Object cursor = claims.toJSONObject();
+    for (int i = 0; i < segments.length; i++) {
+      if (!(cursor instanceof Map<?, ?> m)) {
+        return Collections.emptySet();
+      }
+      cursor = ((Map<String, Object>) m).get(segments[i]);
+      if (cursor == null) {
+        return Collections.emptySet();
+      }
+    }
+    if (!(cursor instanceof List<?> list)) {
+      return Collections.emptySet();
+    }
+    Set<String> roles = new HashSet<>();
+    for (Object o : list) {
+      if (o instanceof String s) {
+        roles.add(s);
+      }
+    }
     return Collections.unmodifiableSet(roles);
   }
 
@@ -350,13 +487,26 @@ public final class TokenEnforcer {
         .withBody(writeAsString(error));
   }
 
+  private String describeRolesByMethod() {
+    StringBuilder sb = new StringBuilder("{");
+    boolean first = true;
+    for (Map.Entry<String, String[]> e : rolesByMethod.entrySet()) {
+      if (!first) {
+        sb.append(", ");
+      }
+      first = false;
+      sb.append(e.getKey()).append('=').append(Arrays.toString(e.getValue()));
+    }
+    return sb.append('}').toString();
+  }
+
   private static String resolve(String envVar, String sysProp, String defaultVal) {
     String val = System.getProperty(sysProp);
-    if (val != null && !val.isEmpty()) {
+    if (val != null) {
       return val;
     }
     val = System.getenv(envVar);
-    if (val != null && !val.isEmpty()) {
+    if (val != null) {
       return val;
     }
     return defaultVal;

--- a/src/test/java/org/opentmf/mockserver/token/TokenEnforcerTests.java
+++ b/src/test/java/org/opentmf/mockserver/token/TokenEnforcerTests.java
@@ -371,4 +371,219 @@ class TokenEnforcerTests {
     assertNotNull(wwwAuth);
     assertTrue(wwwAuth.contains("insufficient_scope"));
   }
+
+  // ---- configurable roles-claim path ----
+
+  private TokenEnforcer enforcerWithClaimPath(String claimPath) {
+    return new TokenEnforcer(true, "", LOCAL_KEY_SOURCE, claimPath, defaultRolesByMethod());
+  }
+
+  private static Map<String, String[]> defaultRolesByMethod() {
+    Map<String, String[]> map = new LinkedHashMap<>();
+    map.put("GET", new String[]{"reader", "writer", "admin"});
+    map.put("POST", new String[]{"writer", "admin"});
+    map.put("PUT", new String[]{"writer", "admin"});
+    map.put("PATCH", new String[]{"writer", "admin"});
+    map.put("DELETE", new String[]{"admin"});
+    return map;
+  }
+
+  private String signTokenWithClaim(String issuer, String subject, long expiresInMs,
+      String topLevelKey, Serializable value) {
+    long nowSeconds = System.currentTimeMillis() / 1000;
+    Map<String, Serializable> claims = new LinkedHashMap<>();
+    claims.put("iss", issuer);
+    claims.put("sub", subject);
+    claims.put("iat", nowSeconds);
+    claims.put("exp", nowSeconds + expiresInMs / 1000);
+    claims.put("jti", TSID.Factory.getTsid().toString());
+    claims.put(topLevelKey, value);
+    return JwtKeyProvider.getInstance().signJwt(claims);
+  }
+
+  @Test
+  void rolesClaimPath_topLevelGroups_extractsRoles() {
+    TokenEnforcer enforcer = enforcerWithClaimPath("groups");
+    String token = signTokenWithClaim(ISSUER, "u", 3600_000, "groups",
+        (Serializable) Arrays.asList("admin", "extra"));
+
+    assertNull(enforcer.validateWithRoles(
+        request().withPath("/api/test").withHeader("Authorization", "Bearer " + token),
+        "admin"));
+  }
+
+  @Test
+  void rolesClaimPath_realmAccessRoles_extractsRoles() {
+    TokenEnforcer enforcer = enforcerWithClaimPath("realm_access.roles");
+    String token = signTokenWithRoles(ISSUER, "u", 3600_000, List.of("writer"));
+
+    assertNull(enforcer.validateWithRoles(
+        request().withPath("/api/test").withHeader("Authorization", "Bearer " + token),
+        "writer", "admin"));
+  }
+
+  @Test
+  void rolesClaimPath_deeplyNested_extractsRoles() {
+    TokenEnforcer enforcer =
+        enforcerWithClaimPath("resource_access.my-client.roles");
+
+    LinkedHashMap<String, Serializable> roles = new LinkedHashMap<>();
+    roles.put("roles", (Serializable) List.of("admin"));
+    LinkedHashMap<String, Serializable> resourceAccess = new LinkedHashMap<>();
+    resourceAccess.put("my-client", roles);
+
+    String token = signTokenWithClaim(ISSUER, "u", 3600_000,
+        "resource_access", resourceAccess);
+
+    assertNull(enforcer.validateWithRoles(
+        request().withPath("/api/test").withHeader("Authorization", "Bearer " + token),
+        "admin"));
+  }
+
+  @Test
+  void rolesClaimPath_missingIntermediate_returns403() {
+    TokenEnforcer enforcer = enforcerWithClaimPath("resource_access.my-client.roles");
+    // No resource_access claim at all
+    String token = signToken(ISSUER, "u", 3600_000);
+
+    HttpResponse resp = enforcer.validateWithRoles(
+        request().withPath("/api/test").withHeader("Authorization", "Bearer " + token),
+        "admin");
+    assertNotNull(resp);
+    assertEquals(403, resp.getStatusCode());
+  }
+
+  @Test
+  void rolesClaimPath_leafIsNotArray_returns403() {
+    TokenEnforcer enforcer = enforcerWithClaimPath("groups");
+    String token = signTokenWithClaim(ISSUER, "u", 3600_000, "groups",
+        "not-an-array");
+
+    HttpResponse resp = enforcer.validateWithRoles(
+        request().withPath("/api/test").withHeader("Authorization", "Bearer " + token),
+        "admin");
+    assertNotNull(resp);
+    assertEquals(403, resp.getStatusCode());
+  }
+
+  @Test
+  void rolesClaimPath_configured_ignoresDefaultRealmAccessFallback() {
+    // Token DOES have realm_access.roles=[admin], but the configured path is "groups".
+    // With a configured path, the default fallback chain MUST NOT kick in.
+    TokenEnforcer enforcer = enforcerWithClaimPath("groups");
+    String token = signTokenWithRoles(ISSUER, "u", 3600_000, List.of("admin"));
+
+    HttpResponse resp = enforcer.validateWithRoles(
+        request().withPath("/api/test").withHeader("Authorization", "Bearer " + token),
+        "admin");
+    assertNotNull(resp);
+    assertEquals(403, resp.getStatusCode());
+  }
+
+  @Test
+  void rolesClaimPath_unset_fallsBackToRealmAccessThenTopLevelRoles() {
+    // Path unset: should still find roles at realm_access.roles
+    TokenEnforcer enforcer = enabledEnforcer("");
+    String token = signTokenWithRoles(ISSUER, "u", 3600_000, List.of("reader"));
+
+    assertNull(enforcer.validateWithRoles(
+        request().withPath("/api/test").withHeader("Authorization", "Bearer " + token),
+        "reader"));
+
+    // And to top-level "roles" when realm_access is absent
+    String token2 = signTokenWithClaim(ISSUER, "u", 3600_000, "roles",
+        (Serializable) List.of("reader"));
+
+    assertNull(enforcer.validateWithRoles(
+        request().withPath("/api/test").withHeader("Authorization", "Bearer " + token2),
+        "reader"));
+  }
+
+  // ---- per-method ROLES_* ----
+
+  private TokenEnforcer enforcerWithRolesByMethod(Map<String, String[]> rolesByMethod) {
+    return new TokenEnforcer(true, "", LOCAL_KEY_SOURCE, "", rolesByMethod);
+  }
+
+  @Test
+  void validateForRequest_GET_appliesGetRoles() {
+    TokenEnforcer enforcer = enforcerWithRolesByMethod(defaultRolesByMethod());
+    String token = signTokenWithRoles(ISSUER, "u", 3600_000, List.of("reader"));
+
+    assertNull(enforcer.validateForRequest(
+        request().withMethod("GET").withPath("/x")
+            .withHeader("Authorization", "Bearer " + token)));
+  }
+
+  @Test
+  void validateForRequest_POST_appliesPostRoles_rejectsReader() {
+    TokenEnforcer enforcer = enforcerWithRolesByMethod(defaultRolesByMethod());
+    String token = signTokenWithRoles(ISSUER, "u", 3600_000, List.of("reader"));
+
+    HttpResponse resp = enforcer.validateForRequest(
+        request().withMethod("POST").withPath("/x")
+            .withHeader("Authorization", "Bearer " + token));
+    assertNotNull(resp);
+    assertEquals(403, resp.getStatusCode());
+  }
+
+  @Test
+  void validateForRequest_DELETE_appliesDeleteRoles_rejectsWriter() {
+    TokenEnforcer enforcer = enforcerWithRolesByMethod(defaultRolesByMethod());
+    String token = signTokenWithRoles(ISSUER, "u", 3600_000, List.of("writer"));
+
+    HttpResponse resp = enforcer.validateForRequest(
+        request().withMethod("DELETE").withPath("/x")
+            .withHeader("Authorization", "Bearer " + token));
+    assertNotNull(resp);
+    assertEquals(403, resp.getStatusCode());
+  }
+
+  @Test
+  void validateForRequest_emptyMethodConfig_skipsRoleCheck() {
+    // ROLES_GET="" semantics: no role check, signature/expiry only.
+    Map<String, String[]> map = defaultRolesByMethod();
+    map.put("GET", new String[0]);
+    TokenEnforcer enforcer = enforcerWithRolesByMethod(map);
+
+    // Token has no roles at all — would normally fail under default GET roles.
+    String token = signToken(ISSUER, "u", 3600_000);
+
+    assertNull(enforcer.validateForRequest(
+        request().withMethod("GET").withPath("/x")
+            .withHeader("Authorization", "Bearer " + token)));
+  }
+
+  @Test
+  void validateForRequest_customAdminOnlyGet_rejectsReader() {
+    Map<String, String[]> map = defaultRolesByMethod();
+    map.put("GET", new String[]{"admin"});
+    TokenEnforcer enforcer = enforcerWithRolesByMethod(map);
+
+    String token = signTokenWithRoles(ISSUER, "u", 3600_000, List.of("reader"));
+
+    HttpResponse resp = enforcer.validateForRequest(
+        request().withMethod("GET").withPath("/x")
+            .withHeader("Authorization", "Bearer " + token));
+    assertNotNull(resp);
+    assertEquals(403, resp.getStatusCode());
+  }
+
+  @Test
+  void validateForRequest_methodNotInMap_skipsRoleCheck() {
+    // Unknown method (HEAD/OPTIONS/etc.) falls through to no-role-check.
+    TokenEnforcer enforcer = enforcerWithRolesByMethod(defaultRolesByMethod());
+    String token = signToken(ISSUER, "u", 3600_000);
+
+    assertNull(enforcer.validateForRequest(
+        request().withMethod("HEAD").withPath("/x")
+            .withHeader("Authorization", "Bearer " + token)));
+  }
+
+  @Test
+  void validateForRequest_disabledEnforcer_passesAnyMethod() {
+    TokenEnforcer enforcer = disabledEnforcer();
+    assertNull(enforcer.validateForRequest(
+        request().withMethod("DELETE").withPath("/x")));
+  }
 }


### PR DESCRIPTION
Add ROLES_GET, ROLES_POST, ROLES_PUT, ROLES_PATCH, ROLES_DELETE env vars to override the required roles for each HTTP method (empty value skips the role check while still validating signature, expiry and issuer). Add ROLES_CLAIM_PATH for dotted-path extraction of the roles array from any location in the token (e.g. resource_access.my-client.roles, groups, namespaced custom claims). Defaults preserve the historical behaviour.